### PR TITLE
default text field with browse added

### DIFF
--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationAction.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationAction.kt
@@ -19,7 +19,10 @@ class AddMigrationAction : EfCoreAction() {
             val commonOptions = getCommonOptions(dialog)
 
             executeCommandUnderProgress(intellijProject, "Creating migration...", "New migration has been created") {
-                migrationsClient.add(commonOptions, dialog.model.migrationName.trim())
+                val migrationName = dialog.model.migrationName.trim()
+                val migrationOutputFolder = dialog.model.migrationOutputFolder
+
+                migrationsClient.add(commonOptions, migrationName, migrationOutputFolder)
             }
         }
     }

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
@@ -27,7 +27,7 @@ class AddMigrationDialogWrapper(
 
     //
     // Data binding
-    val model = AddMigrationModel("")
+    val model = AddMigrationModel("", "Migrations")
 
     //
     // Internal data
@@ -35,7 +35,6 @@ class AddMigrationDialogWrapper(
     private var currentDbContextMigrationsList = listOf<String>()
     private var userInputReceived: Boolean = false
     private lateinit var migrationNameTextField: JBTextField
-    private lateinit var migrationProjectFullPath: String
 
     //
     // Validation
@@ -86,7 +85,9 @@ class AddMigrationDialogWrapper(
                 textFieldWithBrowseButton(null, intellijProject, fileChooserDescriptor) {
                     val migrationsFolder : VirtualFile = it
                     formatMigrationFolderPath(migrationsFolder)
-                }.validationOnInput(validator.migrationsOutputFolderValidation())
+                }.bindText(model::migrationOutputFolder)
+                    .horizontalAlign(HorizontalAlign.FILL)
+                    .validationOnInput(validator.migrationsOutputFolderValidation())
                     .validationOnApply(validator.migrationsOutputFolderValidation())
             }
         }
@@ -109,10 +110,7 @@ class AddMigrationDialogWrapper(
     }
 
     private fun onMigrationsProjectChanged(migrationsProjectItem: MigrationsProjectItem) {
-        setMigrationProjectFullPath(migrationsProjectItem)
-
         refreshAvailableMigrations(migrationsProjectItem.displayName)
-
         refreshCurrentDbContextMigrations(commonOptions.dbContext)
     }
 
@@ -154,13 +152,11 @@ class AddMigrationDialogWrapper(
     }
 
     private fun formatMigrationFolderPath(virtualFile: VirtualFile) : String {
+        val migrationProjectFullPath = commonOptions.migrationsProject?.data?.fullPath!!
+
         val migrationProjectFolder = File(migrationProjectFullPath).parentFile.path
         val relativePath = virtualFile.toIOFile().relativeTo(File(migrationProjectFolder)).path
 
         return relativePath
-    }
-
-    private fun setMigrationProjectFullPath(migrationsProjectItem: MigrationsProjectItem) {
-        migrationProjectFullPath = migrationsProjectItem.data.fullPath
     }
 }

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
@@ -1,9 +1,10 @@
 package me.seclerp.rider.plugins.efcore.features.migrations.add
 
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.components.JBTextField
 import com.intellij.ui.dsl.builder.Panel
-import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.jetbrains.rider.util.idea.runUnderProgress
@@ -24,7 +25,7 @@ class AddMigrationDialogWrapper(
 
     //
     // Data binding
-    val model = AddMigrationModel("")
+    val model = AddMigrationModel("", "<Default>")
 
     //
     // Internal data
@@ -32,6 +33,7 @@ class AddMigrationDialogWrapper(
     private var currentDbContextMigrationsList = listOf<String>()
     private var userInputReceived: Boolean = false
     private lateinit var migrationNameTextField: JBTextField
+    private lateinit var migrationFolderTextFieldWithBrowseButton: TextFieldWithBrowseButton
 
     //
     // Validation
@@ -50,6 +52,7 @@ class AddMigrationDialogWrapper(
     // UI
     override fun Panel.createPrimaryOptions() {
         createMigrationNameRow()
+        createMigrationFolderRow()
     }
 
     private fun Panel.createMigrationNameRow() {
@@ -63,6 +66,26 @@ class AddMigrationDialogWrapper(
                 .applyToComponent {
                     document.addDocumentListener(migrationNameChangedListener)
                     migrationNameTextField = this
+                }
+        }
+    }
+
+    private fun Panel.createMigrationFolderRow() {
+        val fileChooserDescriptor =  FileChooserDescriptor(
+            /* chooseFiles = */ false,
+            /* chooseFolders = */ true,
+            /* chooseJars = */ false,
+            /* chooseJarsAsFiles = */ false,
+            /* chooseJarContents = */ false,
+            /* chooseMultiple = */ false
+        )
+
+        row("Migration folder:") {
+            textFieldWithBrowseButton(fileChooserDescriptor = fileChooserDescriptor)
+                .bindText(model::migrationFolder)
+                .horizontalAlign(HorizontalAlign.FILL)
+                .applyToComponent {
+                    migrationFolderTextFieldWithBrowseButton = this
                 }
         }
     }

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
@@ -54,7 +54,6 @@ class AddMigrationDialogWrapper(
     // UI
     override fun Panel.createPrimaryOptions() {
         createMigrationNameRow()
-        createMigrationFolderRow()
     }
 
     private fun Panel.createMigrationNameRow() {
@@ -72,20 +71,40 @@ class AddMigrationDialogWrapper(
         }
     }
 
-    private fun Panel.createMigrationFolderRow() {
-        row("Migration folder:") {
-            val fileChooserDescriptor =  FileChooserDescriptor(
-                /* chooseFiles = */ false,
-                /* chooseFolders = */ true,
-                /* chooseJars = */ false,
-                /* chooseJarsAsFiles = */ false,
-                /* chooseJarContents = */ false,
-                /* chooseMultiple = */ false
-            )
+//    private fun Panel.createMigrationFolderRow() {
+//        row("Migration folder:") {
+//            val fileChooserDescriptor =  FileChooserDescriptor(
+//                /* chooseFiles = */ false,
+//                /* chooseFolders = */ true,
+//                /* chooseJars = */ false,
+//                /* chooseJarsAsFiles = */ false,
+//                /* chooseJarContents = */ false,
+//                /* chooseMultiple = */ false
+//            )
+//
+//            textFieldWithBrowseButton(null, intellijProject, fileChooserDescriptor) {
+//                val migrationsFolder : VirtualFile = it
+//                formatMigrationFolderPath(migrationsFolder)
+//            }
+//        }
+//    }
 
-            textFieldWithBrowseButton(null, intellijProject, fileChooserDescriptor) {
-                val migrationsFolder : VirtualFile = it
-                formatMigrationFolderPath(migrationsFolder)
+    override fun Panel.createAdditionalGroup() {
+        groupRowsRange("Additional Options"){
+            row("Migrations folder:") {
+                val fileChooserDescriptor =  FileChooserDescriptor(
+                    /* chooseFiles = */ false,
+                    /* chooseFolders = */ true,
+                    /* chooseJars = */ false,
+                    /* chooseJarsAsFiles = */ false,
+                    /* chooseJarContents = */ false,
+                    /* chooseMultiple = */ false
+                )
+
+                textFieldWithBrowseButton(null, intellijProject, fileChooserDescriptor) {
+                    val migrationsFolder : VirtualFile = it
+                    formatMigrationFolderPath(migrationsFolder)
+                }
             }
         }
     }

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
@@ -71,24 +71,6 @@ class AddMigrationDialogWrapper(
         }
     }
 
-//    private fun Panel.createMigrationFolderRow() {
-//        row("Migration folder:") {
-//            val fileChooserDescriptor =  FileChooserDescriptor(
-//                /* chooseFiles = */ false,
-//                /* chooseFolders = */ true,
-//                /* chooseJars = */ false,
-//                /* chooseJarsAsFiles = */ false,
-//                /* chooseJarContents = */ false,
-//                /* chooseMultiple = */ false
-//            )
-//
-//            textFieldWithBrowseButton(null, intellijProject, fileChooserDescriptor) {
-//                val migrationsFolder : VirtualFile = it
-//                formatMigrationFolderPath(migrationsFolder)
-//            }
-//        }
-//    }
-
     override fun Panel.createAdditionalGroup() {
         groupRowsRange("Additional Options"){
             row("Migrations folder:") {

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
@@ -85,9 +85,25 @@ class AddMigrationDialogWrapper(
                 .bindText(model::migrationFolder)
                 .horizontalAlign(HorizontalAlign.FILL)
                 .applyToComponent {
+                    textField.document.addDocumentListener(migrationFolderChangeListener)
                     migrationFolderTextFieldWithBrowseButton = this
                 }
         }
+    }
+
+    private val migrationFolderChangeListener = object : DocumentListener {
+        override fun insertUpdate(e: DocumentEvent?) {
+            TODO("Not yet implemented")
+        }
+
+        override fun removeUpdate(e: DocumentEvent?) {
+            TODO("Not yet implemented")
+        }
+
+        override fun changedUpdate(e: DocumentEvent?) {
+            TODO("Not yet implemented")
+        }
+
     }
 
     //

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
@@ -104,7 +104,8 @@ class AddMigrationDialogWrapper(
                 textFieldWithBrowseButton(null, intellijProject, fileChooserDescriptor) {
                     val migrationsFolder : VirtualFile = it
                     formatMigrationFolderPath(migrationsFolder)
-                }
+                }.validationOnInput(validator.migrationsOutputFolderValidation())
+                    .validationOnApply(validator.migrationsOutputFolderValidation())
             }
         }
     }

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationDialogWrapper.kt
@@ -82,7 +82,7 @@ class AddMigrationDialogWrapper(
                     /* chooseMultiple = */ false
                 )
 
-                textFieldWithBrowseButton(null, intellijProject, fileChooserDescriptor) {
+                textFieldWithBrowseButton("Select Migrations Folder", intellijProject, fileChooserDescriptor) {
                     val migrationsFolder : VirtualFile = it
                     formatMigrationFolderPath(migrationsFolder)
                 }.bindText(model::migrationOutputFolder)

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationModel.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationModel.kt
@@ -1,5 +1,6 @@
 package me.seclerp.rider.plugins.efcore.features.migrations.add
 
 data class AddMigrationModel(
-    var migrationName: String
+    var migrationName: String,
+    var migrationOutputFolder: String
 )

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationModel.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationModel.kt
@@ -1,5 +1,6 @@
 package me.seclerp.rider.plugins.efcore.features.migrations.add
 
 data class AddMigrationModel(
-    var migrationName: String
+    var migrationName: String,
+    var migrationFolder: String
 )

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationModel.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationModel.kt
@@ -1,6 +1,5 @@
 package me.seclerp.rider.plugins.efcore.features.migrations.add
 
 data class AddMigrationModel(
-    var migrationName: String,
-    var migrationFolder: String
+    var migrationName: String
 )

--- a/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationValidator.kt
+++ b/src/rider/main/kotlin/me/seclerp/rider/plugins/efcore/features/migrations/add/AddMigrationValidator.kt
@@ -1,5 +1,6 @@
 package me.seclerp.rider.plugins.efcore.features.migrations.add
 
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.layout.ValidationInfoBuilder
 import javax.swing.JTextField
@@ -10,6 +11,13 @@ class AddMigrationValidator {
             error("Migration name could not be empty")
         else if (currentDbContextMigrationsList.contains(it.text.trim()))
             error("Migration with such name already exist")
+        else
+            null
+    }
+
+    fun migrationsOutputFolderValidation(): ValidationInfoBuilder.(TextFieldWithBrowseButton) -> ValidationInfo? = {
+        if (it.text.trim().isEmpty())
+            error("Migrations output folder could not be empty")
         else
             null
     }


### PR DESCRIPTION
default text field with browse added

TODO:

- Place field under `Additional Options` section. See examples in: Update database (done)
- Label to be: `Migrations folder`  (done)
- Ensure that file dialog is opened at root of `Migrations project`
- Add validation for null or empty (done)
- Update `migrations add` command so that it contains --o flag (done)